### PR TITLE
Removing duplicate 'import queue' statement

### DIFF
--- a/pitft_touchscreen.py
+++ b/pitft_touchscreen.py
@@ -8,7 +8,6 @@ except ImportError:
     print("pip3 install evdev")
     raise(ImportError("evdev not found"))
 import threading
-import queue
 try:
     # python 3.5+
     import queue


### PR DESCRIPTION
Not sure how that got past me.  It would work in Python 3 but not in 2.7 with that line.   In the future I will test in both.