### PR TITLE
Reversing resistive and capacitive list.

### DIFF
--- a/pitft_touchscreen.py
+++ b/pitft_touchscreen.py
@@ -24,8 +24,8 @@ class pitft_touchscreen(threading.Thread):
         self.grab = grab
         self.events = queue.Queue()
         self.shutdown = threading.Event()
-        self.devices_resistive = ["EP0110M09"]    # Support for Adafruit 2.8 Capacitive PiTFT
-        self.devices_capacitive = ["stmpe-ts"]    # Support for Adafruit 2.4, 2.8, 3.2, 3.5 Resistive PiTFT
+        self.devices_capacitive = ["EP0110M09"]    # Support for Adafruit 2.8 Capacitive PiTFT
+        self.devices_resistive = ["stmpe-ts"]    # Support for Adafruit 2.4, 2.8, 3.2, 3.5 Resistive PiTFT
 
     def run(self):
         thread_process = threading.Thread(target=self.process_device)


### PR DESCRIPTION
Cut and paste error had the devices_capacitive being the resistive devices and devices_resistive being the capacitive devices.  Good 1:00 AM coding mistake.